### PR TITLE
MKR1000WiFiRTC: Fix handling of NTP failure

### DIFF
--- a/MKR1000WiFiRTC/MKR1000WiFiRTC.ino
+++ b/MKR1000WiFiRTC/MKR1000WiFiRTC.ino
@@ -64,7 +64,7 @@ void setup() {
   }
   while ((epoch == 0) && (numberOfTries < maxTries));
 
-  if (numberOfTries > maxTries) {
+  if (numberOfTries == maxTries) {
     Serial.print("NTP unreachable!!");
     while (1);
   }


### PR DESCRIPTION
Previously, the sketch would continue to run even after failing to get the time from the NTP server due to a bug in the code.

Originally reported at https://github.com/arduino/tutorials/commit/31ac7dc3dd0a06915e73c668f58ddff5ff974f9b#commitcomment-31379462

CC: @dlcflv